### PR TITLE
Fix footer logo

### DIFF
--- a/src/shared/ui/footer/styled.ts
+++ b/src/shared/ui/footer/styled.ts
@@ -43,6 +43,6 @@ export const Logo = styled.span`
   user-select: none;
 
   @media screen and (max-width: 671px) {
-    font-size: calc(var(--width) * 0.174);
+    display: none;
   }
 `


### PR DESCRIPTION
В макетах надпись "РАЗРАБЫ" отсутствует в футере при ширине экрана меньше 671px
fixes #65 

![image](https://user-images.githubusercontent.com/48432436/171608033-af28c963-d313-41ce-8bd2-cc98a93ba5a4.png)
