### PR TITLE
Fix footer logo

### DIFF
--- a/src/shared/ui/footer/styled.ts
+++ b/src/shared/ui/footer/styled.ts
@@ -43,6 +43,6 @@ export const Logo = styled.span`
   user-select: none;
 
   @media screen and (max-width: 671px) {
-    font-size: calc(var(--width) * 0.174);
+    display: none;
   }
 `

--- a/src/shared/ui/footer/styled.ts
+++ b/src/shared/ui/footer/styled.ts
@@ -45,4 +45,8 @@ export const Logo = styled.span`
   @media screen and (max-width: 671px) {
     display: none;
   }
+
+  @media screen and (min-width: 1900px) {
+    letter-spacing: calc(var(--width) * 0.026);
+  }
 `


### PR DESCRIPTION
fixes: #65 

При ширине экрана меньше 671px:
Было:
![old_671px](https://user-images.githubusercontent.com/48432436/171799450-706f1a48-a47d-4d91-a775-7187bd2ff3d5.png)

Стало:
![new_671px](https://user-images.githubusercontent.com/48432436/171799784-096803d0-32a0-4211-8a87-4267c85c38bb.png)


При ширине экрана больше 1900px:
Было:
![old_1900px](https://user-images.githubusercontent.com/48432436/171799528-1a83b1cc-080f-4f23-8408-c7e27bd68525.png)

Стало:
![new_1900px](https://user-images.githubusercontent.com/48432436/171799548-ec772b33-8fbf-4c29-9442-1c423b51f7fc.png)
 