### PR TITLE
fix(releases & feeds): remove grid item min height

### DIFF
--- a/components/packages/posts/src/row/layout/styled.ts
+++ b/components/packages/posts/src/row/layout/styled.ts
@@ -5,8 +5,9 @@ export const StyledRow = styled.div<SizeProps>`
   display: flex;
   flex-direction: row;
 
-  min-height: ${({ small }) => (small ? '105px' : '140px')};
-  gap: ${({ small }) => (small ? '10px' : '24px')};
+  /* Откуда брались значения на минимальные высоты в 105 и 140 писелей? */
+  /* min-height: ${({ small }) => (small ? '105px' : '140px')}; */
+  gap: ${({ small }) => (small ? '20px' : '24px')};
 
   &:hover {
     .title {


### PR DESCRIPTION
- Удалена минимальная высота у элементов сетки на главной и лентах. Оставлен комментарий с предыдущем стилем - непонятно на каком основании брались значения на минимальную высоту и почему это свойство было применено в принципе
- Изменено расстояние между элементами в ленте для мобильных устройств, теперь расстояние аналогично расстоянию между элементами на главной странице