### PR TITLE
fix: indents for headings in the article

### DIFF
--- a/src/entities/posts/ui/post-reader/ui/styled.ts
+++ b/src/entities/posts/ui/post-reader/ui/styled.ts
@@ -11,7 +11,7 @@ export const ContentWrapper = styled.main`
   grid-gap: 24px;
 
   @media screen and (min-width: 1000px) {
-    margin-top: 64px;
+    margin-top: 50px;
   }
 
   @media screen and (max-width: 999px) {

--- a/src/shared/ui/markdown-renderer/index.tsx
+++ b/src/shared/ui/markdown-renderer/index.tsx
@@ -21,6 +21,66 @@ const COMPONENTS: Components = {
   p: (props) => (
     <Typography {...props} color='primary' lineHeight='140%' size='lg' />
   ),
+  h1: (props) => (
+    <Typography
+      {...props}
+      uppercase
+      as='h2'
+      color='primary'
+      size='xl'
+      weight='medium'
+    />
+  ),
+  h2: (props) => (
+    <Typography
+      {...props}
+      uppercase
+      as='h2'
+      color='primary'
+      size='xl'
+      weight='medium'
+    />
+  ),
+  h3: (props) => (
+    <Typography
+      {...props}
+      uppercase
+      as='h2'
+      color='primary'
+      size='xl'
+      weight='medium'
+    />
+  ),
+  h4: (props) => (
+    <Typography
+      {...props}
+      uppercase
+      as='h2'
+      color='primary'
+      size='xl'
+      weight='medium'
+    />
+  ),
+  h5: (props) => (
+    <Typography
+      {...props}
+      uppercase
+      as='h2'
+      color='primary'
+      size='xl'
+      weight='medium'
+    />
+  ),
+  h6: (props) => (
+    <Typography
+      {...props}
+      uppercase
+      as='h2'
+      color='primary'
+      size='xl'
+      weight='medium'
+    />
+  ),
   code: ({ inline, className, children, ...props }) => {
     const match = /language-(\w+)/.exec(className || '')
     const codeString = String(children).replace(/\n$/, '')
@@ -69,6 +129,15 @@ const StyleWrapper = styled.div`
 
   p {
     margin: 24px 0;
+  }
+
+  h2 {
+    margin-top: 24px;
+  }
+
+  p + h2,
+  pre + h2 {
+    margin-top: 64px;
   }
 
   //TODO parse image to figcaption


### PR DESCRIPTION
В дизайне отсутствуют элементы подзаголовков, поэтому временно все заголовки в теле статьи будут идти как h2

- Добавлены отступы у заголовков
- Исправлен вес шрифта заголовков
- Исправлены высота линии и размер шрифта заголовков 