### PR TITLE
Feature/footer links

### DIFF
--- a/components/packages/typography/src/index.tsx
+++ b/components/packages/typography/src/index.tsx
@@ -2,7 +2,10 @@ import styled from '@emotion/styled'
 
 import type { TypographyProps } from './types'
 
-const defaultProps: Omit<TypographyProps, 'letterSpacing' | 'lineHeight'> = {
+const defaultProps: Omit<
+  TypographyProps,
+  'letterSpacing' | 'lineHeight' | 'href' | 'rel' | 'target'
+> = {
   size: 'lg',
   color: 'primary',
   align: 'left',

--- a/components/packages/typography/src/types.ts
+++ b/components/packages/typography/src/types.ts
@@ -16,4 +16,7 @@ export type TypographyProps = {
   lineHeight: CSSProperties['lineHeight']
   uppercase: boolean
   disableHover: boolean
+  href: string
+  rel: HTMLAnchorElement['rel']
+  target: HTMLAnchorElement['target']
 }

--- a/src/shared/ui/footer/index.tsx
+++ b/src/shared/ui/footer/index.tsx
@@ -13,6 +13,25 @@ import {
   StyledNav,
 } from './styled'
 
+const networkLinks = [
+  {
+    href: 'https://github.com/razrabs-media',
+    label: 'Github',
+  },
+  {
+    href: 'https://www.youtube.com/channel/UC-h5nFU9Qzo72dFW-fC_lkQ',
+    label: 'YT',
+  },
+  {
+    href: 'https://t.me/rzrbs',
+    label: 'TG',
+  },
+  {
+    href: 'https://twitter.com/razraby',
+    label: 'TW',
+  },
+]
+
 export const Footer: FC = () => {
   useResizeWidth()
 
@@ -31,11 +50,15 @@ export const Footer: FC = () => {
                 О нас
               </Typography>
             </Link>
-            <Link passHref href='mailto:razrabschannel@razrabs.ru'>
-              <Typography uppercase as='a' letterSpacing='1px' size='sm'>
-                Связаться
-              </Typography>
-            </Link>
+            <Typography
+              uppercase
+              as='a'
+              href='mailto:razrabschannel@razrabs.ru'
+              letterSpacing='1px'
+              size='sm'
+            >
+              Связаться
+            </Typography>
           </StyledNav>
           <Share>
             <MoreLabel
@@ -46,56 +69,20 @@ export const Footer: FC = () => {
             >
               Еще и тут:
             </MoreLabel>
-            <Link passHref href='https://github.com/razrabs-media'>
+            {networkLinks.map(({ href, label }) => (
               <Typography
+                key={label}
                 uppercase
                 as='a'
+                href={href}
                 letterSpacing='1px'
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
                 rel='noreferrer'
                 size='sm'
                 target='_blank'
               >
-                Github
+                {label}
               </Typography>
-            </Link>
-            <Link
-              passHref
-              href='https://www.youtube.com/channel/UC-h5nFU9Qzo72dFW-fC_lkQ'
-            >
-              <Typography
-                uppercase
-                as='a'
-                letterSpacing='1px'
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                rel='noreferrer'
-                size='sm'
-                target='_blank'
-              >
-                YT
-              </Typography>
-            </Link>
-            <Link passHref href='https://t.me/rzrbs'>
-              <Typography
-                uppercase
-                as='a'
-                letterSpacing='1px'
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                rel='noreferrer'
-                size='sm'
-                target='_blank'
-              >
-                TG
-              </Typography>
-            </Link>
-            <Link passHref href='https://twitter.com/razraby'>
-              <Typography uppercase as='a' letterSpacing='1px' size='sm'>
-                TW
-              </Typography>
-            </Link>
+            ))}
           </Share>
         </Menu>
       </Content>


### PR DESCRIPTION
1) Добавил в тайпинги TypographyProps возможность добавлять атрибуты тега <a> без @ts-ignore
2) Убрал ненужное использование next/link  в футере
3) сделал ссылки "еще и тут" массивом

p.s. можно еще докинуть target="_blank" на ссылку с mailto но не уверен что так задумано