### PR TITLE
feat: Добавил в мобильной версии сайта отображение названия статьи в заголовке блока комментариев

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -35,7 +35,11 @@ const _App = memo(({ Component, pageProps }: AppProps) => {
       <ThemeProvider theme={themeDark}>
         <ApolloProvider client={apolloClient}>
           <CommentsProvider>
-            <Layout drawerContent={<CommentsWidget />}>
+            <Layout
+              drawerContent={
+                <CommentsWidget postTitle={pageProps.post?.title} />
+              }
+            >
               <Header currentTime={pageProps.currentTime} />
 
               <Component {...pageProps} />

--- a/src/widgets/comments/ui/index.tsx
+++ b/src/widgets/comments/ui/index.tsx
@@ -1,6 +1,7 @@
 import Comment from '@razrabs-ui/comments'
+import { useIsMobile } from '@razrabs-ui/responsive'
 import { useRouter } from 'next/router'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useSendComment } from 'widgets/comments/model'
 import { useCurrentUserLazyQuery } from 'features/auth'
 import { commentAdapter, useContextComments } from 'entities/comments'
@@ -20,15 +21,19 @@ import {
   CommentsContainer,
   CommentsLogin,
   Header,
+  HeaderTexts,
+  PostTitle,
 } from './styled'
+import { Props } from './types'
 
 const TRANSITION_TIME = 150
 
-export const CommentsWidget = () => {
+export const CommentsWidget: FC<Props> = ({ postTitle }) => {
   const router = useRouter()
   const refContainer = useRef<HTMLDivElement>(null)
   const { opened, postUid, comments, closeHandler } = useContextComments()
   const ref = useDisableScroll(opened)
+  const isMobile = useIsMobile()
 
   const [currentUserQuery, { data }] = useCurrentUserLazyQuery({
     errorPolicy: 'all',
@@ -108,7 +113,11 @@ export const CommentsWidget = () => {
       transitionTime={TRANSITION_TIME}
     >
       <Header>
-        <CommentsAmount>Комменты: {comments?.length}</CommentsAmount>
+        <HeaderTexts>
+          <CommentsAmount>Комменты: {comments?.length}</CommentsAmount>
+
+          {postTitle && isMobile && <PostTitle>{postTitle}</PostTitle>}
+        </HeaderTexts>
 
         <IconButton color='primary' onClick={closeHandler}>
           <CrossIcon />

--- a/src/widgets/comments/ui/index.tsx
+++ b/src/widgets/comments/ui/index.tsx
@@ -1,5 +1,5 @@
 import Comment from '@razrabs-ui/comments'
-import { useIsMobile } from '@razrabs-ui/responsive'
+import { useIsTabletAndBelow } from '@razrabs-ui/responsive'
 import { useRouter } from 'next/router'
 import { FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useSendComment } from 'widgets/comments/model'
@@ -33,7 +33,7 @@ export const CommentsWidget: FC<Props> = ({ postTitle }) => {
   const refContainer = useRef<HTMLDivElement>(null)
   const { opened, postUid, comments, closeHandler } = useContextComments()
   const ref = useDisableScroll(opened)
-  const isMobile = useIsMobile()
+  const isTabletAndBelow = useIsTabletAndBelow()
 
   const [currentUserQuery, { data }] = useCurrentUserLazyQuery({
     errorPolicy: 'all',
@@ -116,7 +116,7 @@ export const CommentsWidget: FC<Props> = ({ postTitle }) => {
         <HeaderTexts>
           <CommentsAmount>Комменты: {comments?.length}</CommentsAmount>
 
-          {postTitle && isMobile && <PostTitle>{postTitle}</PostTitle>}
+          {postTitle && isTabletAndBelow && <PostTitle>{postTitle}</PostTitle>}
         </HeaderTexts>
 
         <IconButton color='primary' onClick={closeHandler}>

--- a/src/widgets/comments/ui/styled.ts
+++ b/src/widgets/comments/ui/styled.ts
@@ -8,11 +8,17 @@ export const Header = styled.div`
   flex-direction: row;
   top: 0;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
 
   padding: 18px 22px 18px 24px;
 
   background: ${({ theme }) => theme.colors.backgroundSecondary};
+`
+
+export const HeaderTexts = styled.div`
+  display: flex;
+  white-space: nowrap;
+  overflow: hidden;
 `
 
 export const CommentsAmount = styled(Typography)``
@@ -23,6 +29,20 @@ CommentsAmount.defaultProps = {
   uppercase: true,
   as: 'span',
   letterSpacing: 1,
+}
+
+export const PostTitle = styled(Typography)`
+  margin: 0 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+PostTitle.defaultProps = {
+  size: 'sm',
+  color: 'secondary',
+  uppercase: true,
+  as: 'div',
+  letterSpacing: 1,
+  weight: 'medium',
 }
 
 export const CommentsContainer = styled.div`

--- a/src/widgets/comments/ui/types.ts
+++ b/src/widgets/comments/ui/types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  postTitle?: string
+}


### PR DESCRIPTION
Closes: [#223](https://github.com/razrabs-media/journal/issues/223) 

Дефолтное название публикации на мобильном разрешении:
<img width="533" alt="Снимок экрана 2022-08-03 в 01 41 11" src="https://user-images.githubusercontent.com/28918530/182464639-20dba741-0fff-4f04-b45d-320fa77c68fe.png">

Отображение длинного названия публикации на мобильном разрешении:
<img width="521" alt="Снимок экрана 2022-08-03 в 01 42 05" src="https://user-images.githubusercontent.com/28918530/182464833-7c476b3c-5147-47ce-9462-8dcd82231d7d.png">

Отсутствие отображения названия публикации на десктопе:
<img width="1428" alt="Снимок экрана 2022-08-03 в 01 41 25" src="https://user-images.githubusercontent.com/28918530/182464768-06a45801-ab38-4461-9a1b-0d95d81db4a1.png">

