### PR TITLE
fix: font size adjust on mobile devices #323

### DIFF
--- a/components/packages/typography/src/index.tsx
+++ b/components/packages/typography/src/index.tsx
@@ -36,6 +36,8 @@ const Typography = styled.p<Partial<TypographyProps>>`
   text-transform: ${({ uppercase = defaultProps.uppercase }) =>
     uppercase ? 'uppercase' : 'none'};
 
+  text-size-adjust: 100%;
+
   &:hover {
     ${({ disableHover, theme, color = defaultProps.color }) =>
       disableHover ? `color: ${theme.colors[color]};` : ''}


### PR DESCRIPTION
https://github.com/razrabs-media/journal/issues/323
Prevent type from being resized in iOS when a device’s orientation changes.