### PR TITLE
Исправление конфигурации dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "yarn" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
![изображение](https://user-images.githubusercontent.com/8469236/182880432-4b9a81a4-0c6b-4cbf-a8be-8ba4eea298c8.png)
Для yarn в ```value``` всё равно указывается ```npm```: [документация](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)