### PR TITLE
Исправление бага: Шрифт при загрузке с засечками, а должен быть без

### DIFF
--- a/components/packages/typography/src/index.tsx
+++ b/components/packages/typography/src/index.tsx
@@ -20,7 +20,7 @@ const Typography = styled.p<Partial<TypographyProps>>`
 
   color: ${({ theme, color = defaultProps.color }) => theme.colors[color]};
 
-  font-family: Styrene B LC, serif;
+  font-family: Styrene B LC, sans-serif;
   font-feature-settings: 'salt' on;
 
   font-size: ${({ theme, size = defaultProps.size }) => theme.fontSizes[size]};

--- a/src/shared/ui/copy-button/index.tsx
+++ b/src/shared/ui/copy-button/index.tsx
@@ -15,7 +15,7 @@ const CopyButtonWrapper = styled.button<{ disabled: boolean }>`
   cursor: ${({ disabled }) => (disabled ? 'unset' : 'pointer')};
   outline: inherit;
 
-  font-family: 'JetBrainsMono', serif;
+  font-family: 'JetBrainsMono', sans-serif;
   font-size: 14px;
 
   color: ${({ theme }) => theme.colors.secondary};

--- a/src/shared/ui/share-button/ui/index.tsx
+++ b/src/shared/ui/share-button/ui/index.tsx
@@ -16,7 +16,7 @@ export const StyledButton = styled.button`
   padding: 0;
   margin: 0;
   color: ${({ theme }) => theme.colors.secondary};
-  font-family: Styrene B LC, serif;
+  font-family: Styrene B LC, sans-serif;
   font-feature-settings: 'salt' on;
   font-size: 12px;
   font-weight: 400;


### PR DESCRIPTION
По умолчанию нужно установить шрифты без засечек.
Чтобы при слабом интернете, когда не подгрузился кастомный шрифты,
интерфейс был более похожим на то что ожидалось

-----

Пример слабого интернета. и что видит юзер
<img width="1431" alt="image" src="https://user-images.githubusercontent.com/17089422/183262872-81f2348f-d868-44ed-8285-536ef93dca42.png">
