### PR TITLE
fix: incorrect contentRect.width of footer logo

### DIFF
--- a/src/shared/ui/footer/styled.ts
+++ b/src/shared/ui/footer/styled.ts
@@ -93,7 +93,7 @@ export const Copyright = styled.span`
 `
 
 export const Logo = styled.span`
-  margin: 0 calc(var(--width) * -0.014) calc(var(--width) * -0.014);
+  margin: 0 calc(var(--width) * -0.014);
 
   text-transform: uppercase;
   text-align: center;


### PR DESCRIPTION
Скорее всего нижний отрицательный отступ у логотипа в подвале был оставлен случайно. Он влиял на вычисление contentRect.width из-за чего логотип уходил ниже страницы.

Было
![image](https://user-images.githubusercontent.com/35378637/183753656-ea54c34f-46b4-4cb4-87a0-8951ea0e09c5.png)
Стало
![image](https://user-images.githubusercontent.com/35378637/183753729-9560afdc-6402-47b4-a408-cc035e7dd007.png)


