### PR TITLE
fix: Пофиксил отображение бейджа аккаунта, когда в профиле gh указано только имя

### DIFF
--- a/src/widgets/header/ui/preferences/index.tsx
+++ b/src/widgets/header/ui/preferences/index.tsx
@@ -6,6 +6,7 @@ import { EnterIcon, IconButton } from 'shared/ui'
 import { ThemeToggler } from '../themeToggler'
 import { AccountBadge, AuthButton, PreferencesBox } from './styled'
 import { Props } from './types'
+import { getFormattedNameForAccountBadge } from './utils'
 
 export const Preferences: FC<Props> = ({ onClick, toggleTheme }) => {
   const [currentUserQuery, { data }] = useCurrentUserLazyQuery({
@@ -20,13 +21,10 @@ export const Preferences: FC<Props> = ({ onClick, toggleTheme }) => {
     ? IconButton
     : AuthButton
 
-  const fullName = data?.currentUser?.profile?.fullName
+  const fullName = 'georgy kopylov 1'
 
   const title = fullName ? (
-    fullName
-      .split(' ')
-      .map((word) => word[0])
-      .join('')
+    getFormattedNameForAccountBadge(fullName)
   ) : isMobile ? (
     <EnterIcon />
   ) : (

--- a/src/widgets/header/ui/preferences/index.tsx
+++ b/src/widgets/header/ui/preferences/index.tsx
@@ -21,7 +21,7 @@ export const Preferences: FC<Props> = ({ onClick, toggleTheme }) => {
     ? IconButton
     : AuthButton
 
-  const fullName = 'georgy kopylov 1'
+  const fullName = data?.currentUser?.profile?.fullName
 
   const title = fullName ? (
     getFormattedNameForAccountBadge(fullName)

--- a/src/widgets/header/ui/preferences/utils.ts
+++ b/src/widgets/header/ui/preferences/utils.ts
@@ -8,9 +8,13 @@ export const accountBadgeColorByTheme: Record<string, string> = {
 export const getFormattedNameForAccountBadge = (fullName: string): string => {
   const separatedFullName = fullName.split(' ')
 
-  if (separatedFullName.length === 1) {
-    return separatedFullName[0].slice(0, 2)
+  if (!separatedFullName.length) {
+    return ''
   }
 
-  return separatedFullName.map((word) => word[0]).join('')
+  return (
+    separatedFullName.length === 1
+      ? separatedFullName[0].slice(0, 2)
+      : separatedFullName.map((word) => word[0]).join('')
+  ).slice(0, 2)
 }

--- a/src/widgets/header/ui/preferences/utils.ts
+++ b/src/widgets/header/ui/preferences/utils.ts
@@ -4,3 +4,13 @@ export const accountBadgeColorByTheme: Record<string, string> = {
   [themeDark.name]: themeDark.colors.contrastPrimary,
   [themeLight.name]: themeLight.colors.primary,
 }
+
+export const getFormattedNameForAccountBadge = (fullName: string): string => {
+  const separatedFullName = fullName.split(' ')
+
+  if (separatedFullName.length === 1) {
+    return separatedFullName[0].slice(0, 2)
+  }
+
+  return separatedFullName.map((word) => word[0]).join('')
+}

--- a/src/widgets/header/ui/preferences/utils.ts
+++ b/src/widgets/header/ui/preferences/utils.ts
@@ -6,15 +6,14 @@ export const accountBadgeColorByTheme: Record<string, string> = {
 }
 
 export const getFormattedNameForAccountBadge = (fullName: string): string => {
-  const separatedFullName = fullName.split(' ')
+  const separatedFullName = fullName.trim().split(' ')
 
-  if (!separatedFullName.length) {
-    return ''
+  if (separatedFullName.length === 1) {
+    return separatedFullName[0].slice(0, 2)
   }
 
-  return (
-    separatedFullName.length === 1
-      ? separatedFullName[0].slice(0, 2)
-      : separatedFullName.map((word) => word[0]).join('')
-  ).slice(0, 2)
+  return separatedFullName
+    .map((word) => word[0])
+    .join('')
+    .slice(0, 2)
 }


### PR DESCRIPTION
closes #415 
Кейс при имени 'Georgy' в GH:
<img width="184" alt="Снимок экрана 2022-08-19 в 14 40 13" src="https://user-images.githubusercontent.com/28918530/185582023-2121171c-fbe6-4922-90ce-584ec42c0e54.png">

Кейс при имени 'Georgy Kopylov' в GH:
<img width="184" alt="Снимок экрана 2022-08-19 в 14 40 22" src="https://user-images.githubusercontent.com/28918530/185582057-3800631b-5720-42fd-8487-6bc0eed8ecbd.png">

Кейс при имени 'Georgy Kopylov I' в GH:
<img width="184" alt="Снимок экрана 2022-08-19 в 14 40 22" src="https://user-images.githubusercontent.com/28918530/185582094-958b0742-886d-4d82-8c24-cd5a427e375a.png">

